### PR TITLE
[feature] Mulitple Filter/FilterByAnd/FilterByOr on the same property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+/node_modules
+/public/hot
+/public/storage
+/storage/*.key
+/vendor
+.env
+.env.backup
+.phpunit.result.cache
+docker-compose.override.yml
+Homestead.json
+Homestead.yaml
+npm-debug.log
+yarn-error.log
+/storage/api-docs

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -47,6 +47,7 @@ The way a filter should be formed is:
 
 Another available parameter is `filterByOr`, `search` and `searchByOr`. 
 
+* [] - (Optional) In case of using multiple `filterBy` or `filterByOr` on the same property.
 * **columnName** -  (Required) - Name of column you want to filter, for relationships use `dots`.
 * **operator** - (Optional | Default: `eq`) Type of operator you want to use.
 * **not** - (Optional | Default: `false`) Negate the filter (Accepted values: not|yes|true|1).
@@ -68,7 +69,7 @@ Filter all books whose author is `Gentrit`.
 Filter all users whose name start with `Gentrit` or ends with `Abazi`.
 
 ```console
-{base_url}/users?filterByOr[name][sw]=Gentrit&filterByOr[name][ew]=Abazi
+{base_url}/users?filterByOr[][name][sw]=Gentrit&filterByOr[][name][ew]=Abazi
 ```
 
 [See other ways for filtering](filters_old.md)

--- a/src/Controllers/LaravelController.php
+++ b/src/Controllers/LaravelController.php
@@ -238,7 +238,14 @@ abstract class LaravelController extends Controller
             'bt',
         ];
 
-        foreach ($filters as $column => $part) {
+        foreach ($filters as $indexOrColumn => $part) {
+            if (is_numeric($indexOrColumn)) {
+                $column = array_key_first($part);
+                $part = $part[$column];
+            } else {
+                $column = $indexOrColumn;
+            }
+
             $arrayCountValues = is_array($part) ? count($part, COUNT_RECURSIVE) : 0;
             $operator = $defaultOperator;
             $not = false;


### PR DESCRIPTION
Actually it's not possible to filter the same property, if we use the actual api only the last filter is used.
For example : 

```console
http://localhost:8080/api/items?filterByOr[code][ct]=A&filterByOr[code][ct]=B
```

this will only consider `filterByOr[code][ct]=B` because of the way php handle array (and it's totally normal)

To have multiple filters on the same property we could add this api : 
```console
{base_url}/items?filterByOr[][code][ct]=A&filterByOr[][code][ct]=B
```

like that we would have an array of filters : and thus the api would become : 
```console
filter / filterByOr
[]
[property]
[operator]
=
VALUE
```

and now the example in the doc with the filtering is correctly working : 

-----
Filter all users whose name start with `Gentrit` or ends with `Abazi`.

```console
{base_url}/users?filterByOr[][name][sw]=Gentrit&filterByOr[][name][ew]=Abazi
```